### PR TITLE
Add `podspec` file

### DIFF
--- a/ReactNativeShareExtension.podspec
+++ b/ReactNativeShareExtension.podspec
@@ -1,0 +1,21 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name         = "ReactNativeShareExtension"
+  s.version      = package['version']
+  s.summary      = package['description']
+  s.license      = package['license']
+
+  s.authors      = package['author']
+  s.homepage     = package['repository']['url']
+  s.platform     = :ios, "9.0"
+  s.ios.deployment_target = '9.0'
+  s.tvos.deployment_target = '10.0'
+
+  s.source       = { :git => "https://github.com/verypossible/react-native-share-extension.git", :tag => "master" }
+  s.source_files  = "ios/**/*.{h,m}"
+
+  s.dependency 'React'
+end


### PR DESCRIPTION
Why:
* RN > 0.60 requires to link libs automatically, so we need to add a `podspec` file to reference it in projects `Podfile`.
Based on: https://github.com/alinz/react-native-share-extension/issues/182#issuecomment-534993812

How:
* Add `podspec` file.